### PR TITLE
Sinkronisasi ML dan candle close pada papertrade

### DIFF
--- a/ml_signal_plugin.py
+++ b/ml_signal_plugin.py
@@ -22,9 +22,25 @@ class MLParams:
     down_prob_thres: float = 0.45
 
 class MLSignal:
-    def __init__(self, coin_cfg: Dict[str, Any] | None):
+    def __init__(
+        self,
+        coin_cfg: Dict[str, Any] | None = None,
+        thr: float = 1.20,
+        htf: str | None = None,
+        heikin: bool = False,
+        model_path: str | None = None,
+        device: str = "cpu",
+    ):
         cfg = coin_cfg or {}
         env = os.environ
+
+        self.coin_cfg = cfg
+        self.thr = float(thr)
+        self.htf = htf
+        self.heikin = bool(heikin)
+        self.model_path = model_path
+        self.device = device
+
         def _getf(key: str, default: float) -> float:
             v = cfg.get(key, env.get(key))
             try: return float(v)


### PR DESCRIPTION
## Ringkasan
- Tambah impor opsional MLSignal dan util `last_closed_kline` serta `ml_gate`
- Perluas argumen CLI untuk threshold ML, HTF, Heikin, biaya dan slippage; gunakan candle terakhir yang sudah tertutup
- Fleksibilitas konstruktor `MLSignal` agar menerima parameter tambahan

## Pengujian
- `python -m py_compile papertrade.py ml_signal_plugin.py`
- `python - <<'PY'
from papertrade import ml_gate, floor_to_step
print(ml_gate(0.55,1.2), ml_gate(0.70,1.2), ml_gate(0.30,1.2))
print(floor_to_step(1.2345,0.001))
print(floor_to_step(1.29,0.1))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a17852ec388328bc8685843bd2ee21