### PR TITLE
Tambahkan eksekusi nyata via Binance Futures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /app
 # Install deps dari requirements.txt (gunakan cache layer)
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
-RUN pip install --no-cache-dir "python-binance>=1.0.19,<2"
+RUN pip install --no-cache-dir "python-binance"
 
 # Copy project
 COPY newrealtrading.py coin_config.json ml_signal_plugin.py engine_core.py /app/


### PR DESCRIPTION
## Ringkasan
- tambahkan `ExecutionClient` untuk kirim order Futures dan rounding sesuai filter
- perluas `CoinTrader` dan `TradingManager` agar mendukung eksekusi nyata serta sizing berdasarkan risiko
- sediakan flag CLI `--real-exec` dan `--testnet` + instalasi `python-binance` di Dockerfile

## Pengujian
- `pip install python-binance`
- `python -m py_compile newrealtrading.py`
- `python newrealtrading.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a34afceaf883289a437956f8469a94