### PR TITLE
Selaraskan sizing dan guard eksekusi serta perbarui Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
+# Dockerfile (Python 3.11, slim)
 FROM python:3.11-slim
-
-ENV PIP_NO_CACHE_DIR=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential curl && \
-    rm -rf /var/lib/apt/lists/*
-
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
 WORKDIR /app
-COPY requirements.txt /app/
-RUN pip install -U pip && pip install -U -r requirements.txt
 
-COPY . /app/
+# System deps (opsional untuk build wheel fallback)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      tzdata build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
-# default: tampilkan bantuan
-CMD ["python", "newrealtrading.py", "--help"]
+COPY requirements.txt ./
+RUN pip install --upgrade pip && pip install -r requirements.txt
 
+COPY . .
+# default: masuk shell, jalankan skrip via docker run
+CMD ["bash"]

--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -657,11 +657,14 @@ class TradingManager:
 
     # Hook: implement loop fetch + dispatch ke trader
     def run_once(self, data_map: Dict[str, pd.DataFrame], _balances_unused=None):
+        step_available = 0.0
         any_trader = next(iter(self.traders.values()))
-        try:
-            step_available = any_trader.exec.get_available_balance()
-        except Exception:
-            step_available = 0.0
+        exec_client = getattr(any_trader, "exec", None)
+        if exec_client is not None:
+            try:
+                step_available = exec_client.get_available_balance()
+            except Exception:
+                step_available = 0.0
         for sym in self.symbols:
             trader = self.traders.get(sym)
             df = data_map.get(sym)

--- a/papertrade.py
+++ b/papertrade.py
@@ -274,8 +274,9 @@ class JournaledCoinTrader(CoinTrader):
         super().__init__(symbol, config)
         self.journal = journal
 
-    def _size_position(self, price: float, balance: float) -> float:
-        qty = super()._size_position(price, balance)
+    def _size_position(self, price: float, sl: float, balance: float) -> float:
+        # panggil base method dengan signature yang sama
+        qty = super()._size_position(price, sl, balance)
         # Enforce minNotional bila ada
         try:
             min_not = _to_float(self.config.get("minNotional", 0.0), 0.0)


### PR DESCRIPTION
## Ringkasan
- Sesuaikan parameter `_size_position` di `JournaledCoinTrader` agar sama dengan kelas dasar dan tetap menerapkan batas `minNotional`.
- Lindungi `TradingManager.run_once` saat klien eksekusi tidak ada.
- Gunakan basis Python 3.11 slim dengan instalasi sistem yang bersih pada `Dockerfile`.

## Pengujian
- `python -m py_compile papertrade.py newrealtrading.py`


------
https://chatgpt.com/codex/tasks/task_e_68a417e8db18832889bddafa00ffed32