### PR TITLE
gunakan timestamp bar untuk pending_skip_entries

### DIFF
--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -296,7 +296,8 @@ class CoinTrader:
         self.account_guard = account_guard
         self.verbose = verbose or _to_bool(self.config.get('VERBOSE', os.getenv('VERBOSE','0')), False)
         self.exec = exec_client
-        self._last_seen_len = None
+        self._last_seen_len = None            # legacy (tidak dipakai lagi untuk skip)
+        self.last_bar_close_ts = None         # <- tambah: jejak bar terakhir (UTC close timestamp)
         self.startup_skip_bars = int(self.config.get('startup_skip_bars', 2))
         self.post_restart_skip_entries_bars = int(self.config.get('post_restart_skip_entries_bars', 1))
         self.pending_skip_entries = self.startup_skip_bars
@@ -315,18 +316,21 @@ class CoinTrader:
         """Return DataFrame dengan kolom: timestamp, open, high, low, close, volume"""
         raise NotImplementedError("Implement fetch_recent_klines() sesuai exchange kamu.")
 
-    def _on_new_bar(self, df: pd.DataFrame):
-        curr_len = len(df)
-        if self._last_seen_len is None:
-            self._last_seen_len = curr_len
+    def _on_new_bar(self, last_close_ts):
+        """
+        Panggil fungsi ini dengan 'last_close_ts' (pd.Timestamp/np.int64) bar TERAKHIR (CLOSED).
+        Bila timestamp berubah, berarti 1 bar baru selesai terbentuk.
+        """
+        if self.last_bar_close_ts is None:
+            self.last_bar_close_ts = last_close_ts
             return
-        if curr_len > self._last_seen_len:
-            delta = curr_len - self._last_seen_len
-            self._last_seen_len = curr_len
+        if last_close_ts != self.last_bar_close_ts:
+            # minimal 1 bar baru; untuk kesederhanaan, kurangi 1 (umumnya loop per 1 bar)
+            self.last_bar_close_ts = last_close_ts
             if self.pending_skip_entries > 0:
-                self.pending_skip_entries = max(0, self.pending_skip_entries - delta)
+                self.pending_skip_entries = max(0, self.pending_skip_entries - 1)
             if self.signal_flip_confirm_left > 0:
-                self.signal_flip_confirm_left = max(0, self.signal_flip_confirm_left - delta)
+                self.signal_flip_confirm_left = max(0, self.signal_flip_confirm_left - 1)
 
     def _safe_trailing_params(self) -> Tuple[float, float]:
         taker_fee = _to_float(self.config.get('taker_fee', DEFAULTS['taker_fee']), DEFAULTS['taker_fee'])
@@ -580,7 +584,9 @@ class CoinTrader:
             return 0.0
         heikin = _to_bool(self.config.get('heikin', False), False)
         df = calculate_indicators(df_raw, heikin=heikin)
-        self._on_new_bar(df)
+        # Ambil CLOSE timestamp terakhir (sudah jadi bar, bukan tick berjalan)
+        last_ts = int(df.index[-1]) if hasattr(df.index[-1], '__int__') else df.index[-1]
+        self._on_new_bar(last_ts)
         last = df.iloc[-1]
         price = float(last['close'])
         htf = str(self.config.get('htf', '1h'))


### PR DESCRIPTION
## Ringkasan
- lacak bar berdasarkan timestamp penutupan
- kurangi pending_skip_entries setiap bar baru
- sesuaikan pemanggilan _on_new_bar memakai timestamp terakhir

## Pengujian
- `python -m py_compile newrealtrading.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a54fc833a48328b178836c48f0312a