### PR TITLE
Perbaikan safe_div dan bypass filter ATR oleh ML

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -1,4 +1,12 @@
 {
+  "SYMBOL_DEFAULTS": {
+    "filters": {
+      "enable_atr_body_filter": false,
+      "allow_ml_override": true,
+      "min_atr_threshold": 0.0,
+      "max_body_over_atr": 9.99
+    }
+  },
   "ADAUSDT": {
     "leverage": 15,
     "risk_per_trade": 0.08,

--- a/ml_signal_plugin.py
+++ b/ml_signal_plugin.py
@@ -116,7 +116,7 @@ class MLSignal:
         d = df.copy()
         req = {'close','rsi','macd','atr'}
         if not req.issubset(d.columns): return None, None
-        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'])
+        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'], default=0.0)
         d['lag_ret'] = d['close'].pct_change().shift(1)
         d['vol'] = d['close'].rolling(20).std().shift(1)
         la = int(self.params.lookahead)
@@ -132,7 +132,7 @@ class MLSignal:
         if df is None or df.empty: return None
         d = df.copy()
         if not {'close','rsi','macd','atr'}.issubset(d.columns): return None
-        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'])
+        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'], default=0.0)
         d['lag_ret'] = d['close'].pct_change().shift(1)
         d['vol'] = d['close'].rolling(20).std().shift(1)
         feat_cols = ['rsi','macd','atr','bb_width','lag_ret','vol']

--- a/papertrade.py
+++ b/papertrade.py
@@ -385,6 +385,8 @@ def main():
     ap.add_argument("--timeout", type=int, default=20, help="HTTP timeout seconds")
     ap.add_argument("--retries", type=int, default=6, help="HTTP retries")
     ap.add_argument("--verbose", action="store_true")
+    ap.add_argument("--no-atr-filter", action="store_true", help="Disable ATR/body candle filter (ML always allowed)")
+    ap.add_argument("--ml-override", action="store_true", help="Allow ML to bypass ATR/body filter when triggered")
     args = ap.parse_args()
 
     if not args.instance_id:
@@ -431,6 +433,10 @@ def main():
         merged["heikin"] = rules["heikin"]
         merged["taker_fee"] = rules["fee_bps"] / 10000.0
         merged["SLIPPAGE_PCT"] = rules["slip_bps"] * 0.01
+        if args.no_atr_filter:
+            merged.setdefault('filters', {})['enable_atr_body_filter'] = False
+        if args.ml_override:
+            merged.setdefault('filters', {})['allow_ml_override'] = True
         cfg_by_sym[s] = merged
 
     journal = Journal(os.path.dirname(args.logs_dir), args.instance_id, cfg_by_sym, args.balance)


### PR DESCRIPTION
## Ringkasan
- ubah safe_div agar mendukung Series/ndarray dan tambah utilitas as_float
- izinkan ML melewati filter ATR/body serta tambah flag CLI untuk mengatur filter
- tambahkan setelan default filter di coin_config

## Pengujian
- `python -m py_compile engine_core.py ml_signal_plugin.py newrealtrading.py papertrade.py`
- `python - <<'PY'
import pandas as pd, numpy as np
from engine_core import safe_div
s1 = pd.Series([1,2,0,4])
s2 = pd.Series([1,0,2,0])
print("safe_div Series:", safe_div(s1, s2, default=0.0).tolist())
print("safe_div scalar:", safe_div(10.0, 0.0, default=0.0))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a5f513dc7c8328b6ca6f758268ae2a