### PR TITLE
fix(types,rounding,filters,ml): vector-safe helpers, symbol guards, soft filters, restore DECISION logging, remove Series truthiness, and align rounding across modes

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -1,8 +1,8 @@
 {
   "SYMBOL_DEFAULTS": {
     "filters": {
-      "enable_atr_body_filter": false,
-      "allow_ml_override": true,
+      "atr_filter_enabled": false,
+      "body_filter_enabled": false,
       "min_atr_threshold": 0.0,
       "max_body_over_atr": 9.99
     }

--- a/ml_signal_plugin.py
+++ b/ml_signal_plugin.py
@@ -116,7 +116,7 @@ class MLSignal:
         d = df.copy()
         req = {'close','rsi','macd','atr'}
         if not req.issubset(d.columns): return None, None
-        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'], default=0.0)
+        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'])
         d['lag_ret'] = d['close'].pct_change().shift(1)
         d['vol'] = d['close'].rolling(20).std().shift(1)
         la = int(self.params.lookahead)
@@ -132,7 +132,7 @@ class MLSignal:
         if df is None or df.empty: return None
         d = df.copy()
         if not {'close','rsi','macd','atr'}.issubset(d.columns): return None
-        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'], default=0.0)
+        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'])
         d['lag_ret'] = d['close'].pct_change().shift(1)
         d['vol'] = d['close'].rolling(20).std().shift(1)
         feat_cols = ['rsi','macd','atr','bb_width','lag_ret','vol']


### PR DESCRIPTION
## Summary
- tambah helper numerik vector-safe (to_scalar, to_bool, safe_div, floor/ceil) dan perbarui fungsi manajemen risiko
- ganti ExecutionClient dengan validasi simbol & rounding via step/tick size, serta filter ATR/BODY non-blocking yang tetap mencetak DECISION
- selaraskan papertrade dengan live melalui opsi --no-atr-filter/--no-body-filter dan pembulatan grid yang konsisten

## Testing
- `python -m py_compile engine_core.py ml_signal_plugin.py newrealtrading.py papertrade.py`
- `python papertrade.py --live-paper --symbols "ADAUSDT,DOGEUSDT,XRPUSDT,NEIROUSDT" --interval 15m --balance 25 --risk_pct 0.01 --verbose --coin_config coin_config.json --logs_dir logs --ml-thr 1.0 --fee_bps 10 --slip_bps 0 --no-atr-filter --no-body-filter` *(gagal: Service unavailable from a restricted location)*

------
https://chatgpt.com/codex/tasks/task_e_68a6302e8530832890d22ff79fb54df2