### PR TITLE
Sinkron logika entry dengan backtest dan normalisasi numerik

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -1,8 +1,8 @@
 {
   "SYMBOL_DEFAULTS": {
     "filters": {
-      "atr_filter_enabled": false,
-      "body_filter_enabled": false,
+      "atr": false,
+      "body": false,
       "min_atr_threshold": 0.0,
       "max_body_over_atr": 9.99
     }

--- a/ml_signal_plugin.py
+++ b/ml_signal_plugin.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
 
-from engine_core import SAFE_EPS, safe_div
+from engine_core import SAFE_EPS
 
 @dataclass
 class MLParams:
@@ -116,7 +116,7 @@ class MLSignal:
         d = df.copy()
         req = {'close','rsi','macd','atr'}
         if not req.issubset(d.columns): return None, None
-        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'])
+        d['bb_width'] = (d['close'].rolling(20).std() * 4.0 / d['close']).replace([np.inf, -np.inf], 0.0)
         d['lag_ret'] = d['close'].pct_change().shift(1)
         d['vol'] = d['close'].rolling(20).std().shift(1)
         la = int(self.params.lookahead)
@@ -132,7 +132,7 @@ class MLSignal:
         if df is None or df.empty: return None
         d = df.copy()
         if not {'close','rsi','macd','atr'}.issubset(d.columns): return None
-        d['bb_width'] = safe_div((d['close'].rolling(20).std() * 4.0), d['close'])
+        d['bb_width'] = (d['close'].rolling(20).std() * 4.0 / d['close']).replace([np.inf, -np.inf], 0.0)
         d['lag_ret'] = d['close'].pct_change().shift(1)
         d['vol'] = d['close'].rolling(20).std().shift(1)
         feat_cols = ['rsi','macd','atr','bb_width','lag_ret','vol']


### PR DESCRIPTION
## Ringkasan
- Tambah utilitas numerik `as_scalar`, `safe_div`, dan pembulatan step/tick berbasis numpy.
- Terapkan logika sinyal backtest (EMA/MA crossover + MACD + RSI moderat) dengan skor ML berbobot.
- Ubah filter ATR/Body menjadi informasi saja serta sesuaikan config default.

## Pengujian
- `python -m py_compile engine_core.py ml_signal_plugin.py newrealtrading.py`
- `python - <<'PY' ...` (simulasi keputusan DOGE/XRP)
- `python papertrade.py --live-paper --symbols "ADAUSDT,DOGEUSDT,XRPUSDT,NEIROUSDT" --interval 15m --balance 25 --risk_pct 0.01 --verbose --coin_config coin_config.json --logs_dir logs --ml-thr 1.0 --fee_bps 10 --slip_bps 0` *(gagal: API Binance diblokir lokasi)*

------
https://chatgpt.com/codex/tasks/task_e_68a6608332e88328a942e413a92acfd1