### PR TITLE
Selaraskan filter ATR & body pada konfigurasi

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -2,8 +2,8 @@
   "SYMBOL_DEFAULTS": {
     "rsi_mode": "PULLBACK",
     "filters": {
-      "atr": true,
-      "body": true,
+      "atr_filter_enabled": true,
+      "body_filter_enabled": true,
       "min_atr_threshold": 0.00,
       "max_body_over_atr": 9.99,
       "min_bb_width": 0.0
@@ -17,7 +17,7 @@
     "margin_type": "ISOLATED",
     "startup_skip_bars": 0,
     "max_atr_pct": 0.04,
-    "max_body_atr": 1.75,
+    "max_body_atr": 2.50,
     "use_htf_filter": 0,
     "cooldown_seconds": 900,
     "sl_mode": "ATR",

--- a/engine_core.py
+++ b/engine_core.py
@@ -327,8 +327,10 @@ def apply_filters(ind: pd.Series, coin_cfg: Dict[str, Any]) -> Tuple[bool, bool,
     max_atr = _to_float(coin_cfg.get('max_atr_pct', 1.0), 1.0)
     max_body = _to_float(coin_cfg.get('max_body_atr', 999.0), 999.0)
     min_bb = _to_float(filters_cfg.get('min_bb_width', 0.0), 0.0)
-    atr_filter_enabled = bool(filters_cfg.get('atr_filter_enabled', True))
-    body_filter_enabled = bool(filters_cfg.get('body_filter_enabled', True))
+    atr_filter_enabled = bool(filters_cfg.get('atr_filter_enabled',
+                               filters_cfg.get('atr', True)))
+    body_filter_enabled = bool(filters_cfg.get('body_filter_enabled',
+                               filters_cfg.get('body', True)))
 
     atr_ok = (ind['atr_pct'] >= min_atr) and (ind['atr_pct'] <= max_atr)
 

--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -757,8 +757,10 @@ class CoinTrader:
             min_atr_threshold = _to_float(filters_cfg.get('min_atr_threshold', self.config.get('min_atr_pct', DEFAULTS['min_atr_pct'])), DEFAULTS['min_atr_pct'])
             max_body_over_atr = _to_float(filters_cfg.get('max_body_over_atr', self.config.get('max_body_atr', DEFAULTS['max_body_atr'])), DEFAULTS['max_body_atr'])
             min_bb_width = _to_float(filters_cfg.get('min_bb_width', 0.0), 0.0)
-            atr_filter_enabled = bool(filters_cfg.get('atr_filter_enabled', True))
-            body_filter_enabled = bool(filters_cfg.get('body_filter_enabled', True))
+            atr_filter_enabled = bool(filters_cfg.get('atr_filter_enabled',
+                                           filters_cfg.get('atr', True)))
+            body_filter_enabled = bool(filters_cfg.get('body_filter_enabled',
+                                           filters_cfg.get('body', True)))
 
             atr_ok = (last['atr_pct'] >= min_atr_threshold) and (
                 last['atr_pct'] <= _to_float(self.config.get('max_atr_pct', DEFAULTS['max_atr_pct']), DEFAULTS['max_atr_pct'])
@@ -771,12 +773,6 @@ class CoinTrader:
                 body_ok = True
             bb_val = as_float(last.get('bb_width_pct', 0.0))
             bb_ok = bb_val >= min_bb_width
-            atr_enabled = _to_bool(filters_cfg.get('atr_filter_enabled', True), True)
-            body_enabled = _to_bool(filters_cfg.get('body_filter_enabled', True), True)
-            if not atr_enabled:
-                atr_ok = True
-            if not body_enabled:
-                body_ok = True
             if self.verbose and (not atr_ok or not body_ok or not bb_ok):
                 print(f"[{self.symbol}] FILTER INFO atr_ok={atr_ok} body_ok={body_ok} bb_ok={bb_ok} price={price} pos={self.pos.side or 'None'}")
 


### PR DESCRIPTION
## Ringkasan
- Ganti kunci `atr`/`body` menjadi `atr_filter_enabled` dan `body_filter_enabled` serta naikkan `max_body_atr` ADA.
- Tambah fallback kunci lama `atr`/`body` pada engine dan hormati `min_bb_width`.
- Perbaiki pemeriksaan sinyal agar menghormati toggle filter dan log status Bollinger Band.

## Pengujian
- `python -m py_compile engine_core.py newrealtrading.py newbacktester_scalping.py`
- `python newbacktester_scalping.py --symbol ADAUSDT --csv /path/ADAUSDT_5m_2025-06-01_to_2025-08-16.csv --use-ml 1 --ml-thr 2.0 --steps 1500` (gagal: FileNotFoundError)
- `python newbacktester_scalping.py --symbol ADAUSDT --csv /path/ADAUSDT_5m_2025-06-01_to_2025-08-16.csv --no-body-filter --steps 1500` (gagal: FileNotFoundError)


------
https://chatgpt.com/codex/tasks/task_e_68a7fc100c948328b21790b670467886