### PR TITLE
Gabungkan config simbol dan atur filter default

### DIFF
--- a/engine_core.py
+++ b/engine_core.py
@@ -138,8 +138,22 @@ def load_coin_config(path: str) -> Dict[str, Any]:
         return {}
 
 def merge_config(symbol: str, base_cfg: Dict[str, Any]) -> Dict[str, Any]:
-    sym_cfg = base_cfg.get(symbol, {}) if isinstance(symbol, str) else {}
-    return dict(sym_cfg)
+    """
+    Gabungkan SYMBOL_DEFAULTS -> override oleh config per-simbol.
+    Termasuk merge nested 'filters'.
+    """
+    merged: Dict[str, Any] = {}
+    if isinstance(base_cfg, dict):
+        merged.update(base_cfg.get("SYMBOL_DEFAULTS", {}))
+        sym_cfg = base_cfg.get(symbol, {}) if isinstance(symbol, str) else {}
+        # merge 'filters' nested
+        f = dict(merged.get("filters", {}))
+        f.update(sym_cfg.get("filters", {}))
+        merged.update({k: v for k, v in sym_cfg.items() if k != "filters"})
+        if f:
+            merged["filters"] = f
+    merged["symbol"] = symbol
+    return merged
 
 # -----------------------------------------------------
 # Indikator & sinyal sederhana
@@ -327,10 +341,11 @@ def apply_filters(ind: pd.Series, coin_cfg: Dict[str, Any]) -> Tuple[bool, bool,
     max_atr = _to_float(coin_cfg.get('max_atr_pct', 1.0), 1.0)
     max_body = _to_float(coin_cfg.get('max_body_atr', 999.0), 999.0)
     min_bb = _to_float(filters_cfg.get('min_bb_width', 0.0), 0.0)
+    # default-kan OFF; hormati alias lama 'atr'/'body' jika ada
     atr_filter_enabled = bool(filters_cfg.get('atr_filter_enabled',
-                               filters_cfg.get('atr', True)))
+                               filters_cfg.get('atr', False)))
     body_filter_enabled = bool(filters_cfg.get('body_filter_enabled',
-                               filters_cfg.get('body', True)))
+                               filters_cfg.get('body', False)))
 
     atr_ok = (ind['atr_pct'] >= min_atr) and (ind['atr_pct'] <= max_atr)
 
@@ -344,7 +359,10 @@ def apply_filters(ind: pd.Series, coin_cfg: Dict[str, Any]) -> Tuple[bool, bool,
     bb_ok = bb_val >= min_bb
     if not atr_ok or not body_ok or not bb_ok:
         logging.getLogger(__name__).info(
-            f"[{coin_cfg.get('symbol', '?')}] FILTER INFO atr_ok={atr_ok} body_ok={body_ok} bb_ok={bb_ok} price={ind.get('close')}"
+            f"[{coin_cfg.get('symbol', '?')}] FILTER INFO atr_ok={atr_ok} body_ok={body_ok} "
+            f"bb_ok={bb_ok} price={ind.get('close')} pos=None "
+            f"metrics(atr_pct={float(ind['atr_pct']):.4f}, body_to_atr={float(body_val) if body_val is not None else float('nan'):.4f}, "
+            f"bb_width_pct={bb_val:.4f})"
         )
     return atr_ok and bb_ok, body_ok, {
         'atr_pct': float(ind['atr_pct']),

--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -757,10 +757,11 @@ class CoinTrader:
             min_atr_threshold = _to_float(filters_cfg.get('min_atr_threshold', self.config.get('min_atr_pct', DEFAULTS['min_atr_pct'])), DEFAULTS['min_atr_pct'])
             max_body_over_atr = _to_float(filters_cfg.get('max_body_over_atr', self.config.get('max_body_atr', DEFAULTS['max_body_atr'])), DEFAULTS['max_body_atr'])
             min_bb_width = _to_float(filters_cfg.get('min_bb_width', 0.0), 0.0)
+            # default OFF; hormati alias lama untuk kompatibilitas
             atr_filter_enabled = bool(filters_cfg.get('atr_filter_enabled',
-                                           filters_cfg.get('atr', True)))
+                                           filters_cfg.get('atr', False)))
             body_filter_enabled = bool(filters_cfg.get('body_filter_enabled',
-                                           filters_cfg.get('body', True)))
+                                           filters_cfg.get('body', False)))
 
             atr_ok = (last['atr_pct'] >= min_atr_threshold) and (
                 last['atr_pct'] <= _to_float(self.config.get('max_atr_pct', DEFAULTS['max_atr_pct']), DEFAULTS['max_atr_pct'])


### PR DESCRIPTION
## Ringkasan
- Gabungkan SYMBOL_DEFAULTS dengan konfigurasi per-simbol serta merge nested `filters`.
- Filter ATR dan body kini nonaktif bila kunci tidak tersedia, dengan log yang lebih rinci.
- Sesuaikan logic filter di `newrealtrading.py` agar konsisten dengan backtest.

## Pengujian
- `python -m py_compile engine_core.py newrealtrading.py && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68a7ff7e4e4883288e803bccf05de56f