### PR TITLE
sinkronisasi waktu backtest pada trader

### DIFF
--- a/newbacktester_scalping.py
+++ b/newbacktester_scalping.py
@@ -112,7 +112,14 @@ def run_backtest(args) -> tuple[dict, pd.DataFrame]:
     steps = 0
     for i in range(start_i, min(len(df), start_i + args.steps)):
         sub = df.iloc[: i + 1].copy()
-        trader.check_trading_signals(sub, args.balance)
+        # ambil epoch detik dari bar terakhir (virtual clock backtest)
+        last_ts = sub['timestamp'].iloc[-1]
+        try:
+            # dukung berbagai tipe ts (pandas/np/datetime)
+            bar_ts = pd.Timestamp(last_ts).to_pydatetime().timestamp()
+        except Exception:
+            bar_ts = float(pd.to_datetime(last_ts).timestamp())
+        trader.check_trading_signals(sub, args.balance, now_ts=float(bar_ts))
         steps += 1
     elapsed = time.time() - t0
 


### PR DESCRIPTION
## Ringkasan
- dukungan `now_ts` untuk jam virtual serta fungsi `_cooldown_active` dan `_to_dt`
- `check_trading_signals` memanfaatkan jam virtual untuk cooldown, entry, dan time-stop
- backtester mengirim timestamp bar ke trader

## Pengujian
- `python -m py_compile newrealtrading.py newbacktester_scalping.py`


------
https://chatgpt.com/codex/tasks/task_e_68a805dc39cc8328adb251c457abb4ba