### PR TITLE
tambah preset SCALP-ADA-15M dan konfirmasi MACD opsional

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -1,10 +1,53 @@
 {
+  "PRESETS": {
+    "SCALP-ADA-15M": {
+      "heikin": false,
+      "rsi_mode": "PULLBACK",
+      "use_macd_confirm": true,
+      "use_htf_filter": 0,
+      "leverage": 15,
+      "risk_per_trade": 0.06,
+      "taker_fee": 0.0005,
+      "min_atr_pct": 0.003,
+      "max_atr_pct": 0.04,
+      "max_body_atr": 1.2,
+      "cooldown_seconds": 120,
+      "min_bars_between_entries": 0,
+      "no_cooldown_on_profit": 1,
+      "sl_mode": "ATR",
+      "sl_atr_mult": 1.7,
+      "sl_min_pct": 0.009,
+      "sl_max_pct": 0.035,
+      "use_breakeven": 1,
+      "be_trigger_pct": 0.0045,
+      "be_min_gap_pct": 0.0001,
+      "trailing_trigger": 0.7,
+      "trailing_step": 0.35,
+      "max_hold_seconds": 3600,
+      "time_stop_only_if_loss": 1,
+      "min_roi_to_close_by_time": 0.0,
+      "ml": {
+        "strict": true,
+        "up_prob_long": 0.6,
+        "down_prob_short": 0.4,
+        "score_threshold": 1.6,
+        "weight": 1.0
+      },
+      "filters": {
+        "atr_filter_enabled": true,
+        "body_filter_enabled": true,
+        "min_atr_threshold": 0.003,
+        "max_body_over_atr": 1.2,
+        "min_bb_width": 0.002
+      }
+    }
+  },
   "SYMBOL_DEFAULTS": {
     "rsi_mode": "PULLBACK",
     "filters": {
       "atr_filter_enabled": false,
       "body_filter_enabled": false,
-      "min_atr_threshold": 0.00,
+      "min_atr_threshold": 0.0,
       "max_body_over_atr": 9.99,
       "min_bb_width": 0.0
     },
@@ -20,7 +63,7 @@
     "margin_type": "ISOLATED",
     "startup_skip_bars": 0,
     "max_atr_pct": 0.04,
-    "max_body_atr": 2.50,
+    "max_body_atr": 2.5,
     "use_htf_filter": 0,
     "cooldown_seconds": 900,
     "sl_mode": "ATR",
@@ -70,7 +113,8 @@
     "quantityPrecision": 0,
     "minNotional": 5.0,
     "SLIPPAGE_PCT": 0.02,
-    "trailing_step_min": 1e-09
+    "trailing_step_min": 1e-09,
+    "use_preset": "SCALP-ADA-15M"
   },
   "DOGEUSDT": {
     "leverage": 15,

--- a/engine_core.py
+++ b/engine_core.py
@@ -252,7 +252,11 @@ def _rsi_midrange(rsi: float, side: str) -> bool:
 
 
 def compute_base_signals(df: pd.DataFrame, coin_cfg: Dict[str, Any] | None = None) -> tuple[bool, bool]:
-    """Hitung sinyal dasar berbasis tren EMA vs SMA dan rentang RSI.
+    """
+    Hitung sinyal dasar berbasis tren EMA vs SMA + rentang RSI.
+    (OPSI) Konfirmasi MACD jika diaktifkan pada config:
+      - LONG: macd > macd_signal
+      - SHORT: macd < macd_signal
     rsi_mode default PULLBACK.
     """
     coin_cfg = coin_cfg or {}
@@ -269,8 +273,15 @@ def compute_base_signals(df: pd.DataFrame, coin_cfg: Dict[str, Any] | None = Non
     else:
         long_ok = trend_up and _rsi_pullback(rsi_now, 'LONG')
         short_ok = trend_dn and _rsi_pullback(rsi_now, 'SHORT')
+    # (opsional) MACD confirm
+    if bool(coin_cfg.get("use_macd_confirm", True)):
+        macd_val = float(last.get('macd', 0.0))
+        macd_sig = float(last.get('macd_signal', 0.0))
+        long_ok  = bool(long_ok  and (macd_val > macd_sig))
+        short_ok = bool(short_ok and (macd_val < macd_sig))
+
     logging.getLogger(__name__).info(
-        f"BASE ema22={ema:.6f} ma22={ma:.6f} rsi={rsi_now:.2f} mode={mode} -> L={long_ok} S={short_ok}"
+        f"BASE ema22={ema:.6f} ma22={ma:.6f} rsi={rsi_now:.2f} mode={mode} macd={float(last.get('macd',0)):.6f}/{float(last.get('macd_signal',0)):.6f} -> L={long_ok} S={short_ok}"
     )
     return bool(long_ok), bool(short_ok)
 

--- a/newbacktester_scalping.py
+++ b/newbacktester_scalping.py
@@ -34,6 +34,13 @@ def run_backtest(args) -> tuple[dict, pd.DataFrame]:
     with open(args.coin_config, "r") as f:
         cfg = json.load(f)
     sym_cfg = cfg.get(args.symbol, {})
+    # (opsi) merge preset dari coin_config["PRESETS"]
+    preset_name = args.preset or sym_cfg.get("use_preset")
+    if preset_name and isinstance(cfg.get("PRESETS"), dict) and preset_name in cfg["PRESETS"]:
+        p = dict(cfg["PRESETS"][preset_name])
+        # preset sebagai base, lalu override oleh per-simbol
+        merged = {**p, **sym_cfg}
+        sym_cfg = merged
     sym_cfg["heikin"] = bool(args.heikin)
     sym_cfg["rsi_mode"] = args.rsi_mode
     sym_cfg["taker_fee"] = float(args.fee_bps) / 10000.0
@@ -167,6 +174,7 @@ def main():
     ap.add_argument("--ml-thr", type=float, default=2.0)
     ap.add_argument("--htf", default=None)
     ap.add_argument("--heikin", action="store_true")
+    ap.add_argument("--preset", default=os.getenv("BT_PRESET"), help="Nama preset di coin_config.json/`PRESETS`")
     ap.add_argument("--fee-bps", type=float, default=10.0)
     ap.add_argument("--slip-bps", type=float, default=0.0)
     ap.add_argument("--no-atr-filter", action="store_true")


### PR DESCRIPTION
## Ringkasan
- tambahkan preset `SCALP-ADA-15M` lengkap dengan filter ketat dan trailing agresif
- aktifkan opsi konfirmasi MACD pada fungsi `compute_base_signals`
- dukung argumen `--preset` pada `newbacktester_scalping.py`

## Pengujian
- `python -m py_compile engine_core.py newbacktester_scalping.py`
- `python newbacktester_scalping.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68a818331be083289490c767abd81c84