### PR TITLE
Tambahkan preset LEGACY/STRICT dan opsi MACD confirm

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -1,19 +1,63 @@
 {
   "PRESETS": {
-    "SCALP-ADA-15M": {
+    "SCALP-ADA-15M-LEGACY": {
+      "heikin": false,
+      "rsi_mode": "PULLBACK",
+      "use_macd_confirm": false,
+      "use_htf_filter": 0,
+      "startup_skip_bars": 0,
+      "cooldown_seconds": 0,
+      "min_bars_between_entries": 0,
+      "no_cooldown_on_profit": 1,
+      "leverage": 15,
+      "risk_per_trade": 0.06,
+      "taker_fee": 0.0005,
+      "min_atr_pct": 0.0,
+      "max_atr_pct": 1.0,
+      "max_body_atr": 9.99,
+      "sl_mode": "ATR",
+      "sl_atr_mult": 1.6,
+      "sl_min_pct": 0.008,
+      "sl_max_pct": 0.035,
+      "use_breakeven": 1,
+      "be_trigger_pct": 0.0,
+      "be_min_gap_pct": 0.0001,
+      "trailing_trigger": 0.45,
+      "trailing_step": 0.25,
+      "max_hold_seconds": 3600,
+      "time_stop_only_if_loss": 0,
+      "min_roi_to_close_by_time": -1.0,
+      "ml": {
+        "enabled": false,
+        "strict": false,
+        "up_prob_long": 0.60,
+        "down_prob_short": 0.40,
+        "score_threshold": 1.00,
+        "weight": 1.0
+      },
+      "filters": {
+        "atr_filter_enabled": false,
+        "body_filter_enabled": false,
+        "min_atr_threshold": 0.0,
+        "max_body_over_atr": 9.99,
+        "min_bb_width": 0.0
+      }
+    },
+    "SCALP-ADA-15M-STRICT": {
       "heikin": false,
       "rsi_mode": "PULLBACK",
       "use_macd_confirm": true,
       "use_htf_filter": 0,
+      "startup_skip_bars": 0,
+      "cooldown_seconds": 120,
+      "min_bars_between_entries": 0,
+      "no_cooldown_on_profit": 1,
       "leverage": 15,
       "risk_per_trade": 0.06,
       "taker_fee": 0.0005,
       "min_atr_pct": 0.003,
       "max_atr_pct": 0.04,
       "max_body_atr": 1.2,
-      "cooldown_seconds": 120,
-      "min_bars_between_entries": 0,
-      "no_cooldown_on_profit": 1,
       "sl_mode": "ATR",
       "sl_atr_mult": 1.7,
       "sl_min_pct": 0.009,
@@ -27,18 +71,19 @@
       "time_stop_only_if_loss": 1,
       "min_roi_to_close_by_time": 0.0,
       "ml": {
+        "enabled": true,
         "strict": true,
-        "up_prob_long": 0.6,
-        "down_prob_short": 0.4,
-        "score_threshold": 1.6,
+        "up_prob_long": 0.60,
+        "down_prob_short": 0.40,
+        "score_threshold": 1.60,
         "weight": 1.0
       },
       "filters": {
         "atr_filter_enabled": true,
         "body_filter_enabled": true,
-        "min_atr_threshold": 0.003,
+        "min_atr_threshold": 0.0030,
         "max_body_over_atr": 1.2,
-        "min_bb_width": 0.002
+        "min_bb_width": 0.0020
       }
     }
   },
@@ -56,6 +101,7 @@
     "no_cooldown_on_profit": 1
   },
   "ADAUSDT": {
+    "use_preset": "SCALP-ADA-15M-LEGACY",
     "leverage": 15,
     "risk_per_trade": 0.08,
     "taker_fee": 0.0005,
@@ -113,8 +159,7 @@
     "quantityPrecision": 0,
     "minNotional": 5.0,
     "SLIPPAGE_PCT": 0.02,
-    "trailing_step_min": 1e-09,
-    "use_preset": "SCALP-ADA-15M"
+    "trailing_step_min": 1e-09
   },
   "DOGEUSDT": {
     "leverage": 15,

--- a/engine_core.py
+++ b/engine_core.py
@@ -253,11 +253,10 @@ def _rsi_midrange(rsi: float, side: str) -> bool:
 
 def compute_base_signals(df: pd.DataFrame, coin_cfg: Dict[str, Any] | None = None) -> tuple[bool, bool]:
     """
-    Hitung sinyal dasar berbasis tren EMA vs SMA + rentang RSI.
-    (OPSI) Konfirmasi MACD jika diaktifkan pada config:
+    Hitung sinyal dasar: tren (EMA22 vs MA22) + RSI mode (PULLBACK/MIDRANGE).
+    (Opsional) Konfirmasi MACD jika `use_macd_confirm` = True:
       - LONG: macd > macd_signal
       - SHORT: macd < macd_signal
-    rsi_mode default PULLBACK.
     """
     coin_cfg = coin_cfg or {}
     last = df.iloc[-1]
@@ -274,14 +273,16 @@ def compute_base_signals(df: pd.DataFrame, coin_cfg: Dict[str, Any] | None = Non
         long_ok = trend_up and _rsi_pullback(rsi_now, 'LONG')
         short_ok = trend_dn and _rsi_pullback(rsi_now, 'SHORT')
     # (opsional) MACD confirm
-    if bool(coin_cfg.get("use_macd_confirm", True)):
+    if bool(coin_cfg.get("use_macd_confirm", False)):
         macd_val = float(last.get('macd', 0.0))
         macd_sig = float(last.get('macd_signal', 0.0))
         long_ok  = bool(long_ok  and (macd_val > macd_sig))
         short_ok = bool(short_ok and (macd_val < macd_sig))
 
     logging.getLogger(__name__).info(
-        f"BASE ema22={ema:.6f} ma22={ma:.6f} rsi={rsi_now:.2f} mode={mode} macd={float(last.get('macd',0)):.6f}/{float(last.get('macd_signal',0)):.6f} -> L={long_ok} S={short_ok}"
+        f"BASE ema22={ema:.6f} ma22={ma:.6f} rsi={rsi_now:.2f} "
+        f"mode={mode} macd={float(last.get('macd',0)):.6f}/{float(last.get('macd_signal',0)):.6f} "
+        f"-> L={long_ok} S={short_ok}"
     )
     return bool(long_ok), bool(short_ok)
 


### PR DESCRIPTION
## Ringkasan
- Aktifkan opsi konfirmasi MACD (default mati) pada sinyal dasar.
- Tambahkan preset SCALP-ADA-15M-LEGACY dan SCALP-ADA-15M-STRICT di `coin_config.json` serta gunakan preset LEGACY pada ADAUSDT.
- Perluas `newbacktester_scalping.py` dengan argumen preset, kontrol cooldown, dan propagasi parameter ML ke konfigurasi.

## Pengujian
- `python -m py_compile engine_core.py newbacktester_scalping.py`
- `python newbacktester_scalping.py --symbol ADAUSDT --csv data/ADAUSDT_15m_2025-08-01_to_2025-08-19.csv --steps 2500 --preset SCALP-ADA-15M-LEGACY --use-ml 0 --ml-thr 1.0 --cooldown 0` *(gagal: FileNotFoundError)*
- `python newbacktester_scalping.py --symbol ADAUSDT --csv data/ADAUSDT_15m_2025-08-01_to_2025-08-19.csv --steps 2500 --preset SCALP-ADA-15M-STRICT --use-ml 1 --ml-thr 1.6` *(gagal: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68a81db926fc8328806cb8f34b1d8570