### PR TITLE
Aktifkan ML default dan perbaiki gate HTF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,8 @@ USE_ML=1
 SCORE_THRESHOLD=2.0
 ML_WEIGHT=1.5
 USE_BACKTEST_ENTRY_LOGIC=1
-ML_MIN_TRAIN_BARS=1000
-ML_LOOKAHEAD=8
+ML_MIN_TRAIN_BARS=400
+ML_LOOKAHEAD=5
 ML_RETRAIN_EVERY=120
 ML_UP_PROB=0.55
 ML_DOWN_PROB=0.45
@@ -75,7 +75,7 @@ INTERVAL=15m
 
 # ML + base logic threshold (lihat catatan di bawah)
 # 1.0 = OR (base ATAU ML). 2.0 = AND (base DAN ML).
-ML_THR=1.0
+ML_THR=2.0
 
 # Biaya & slippage simulasi (bps = basis points)
 FEE_BPS=10

--- a/Readme.md
+++ b/Readme.md
@@ -71,9 +71,9 @@ BINANCE_API_SECRET=YOUR_SECRET
 INSTANCE_ID=botA
 # ML & scoring (opsional)
 USE_ML=1
-SCORE_THRESHOLD=1.2
+SCORE_THRESHOLD=2.0
 ML_MIN_TRAIN_BARS=400
-ML_RETRAIN_EVERY=5000
+ML_RETRAIN_EVERY=120
 ```
 
 > `INSTANCE_ID` dipakai untuk `newClientOrderId` dan pemisahan log multi‑bot.
@@ -235,7 +235,7 @@ python newrealtrading.py \
 ### ml\_signal\_plugin.py
 
 * **`MLParams` (dataclass)** — parameter: `use_ml`, `score_threshold`, `min_train_bars`, `lookahead`, `retrain_every_bars`, `up_prob_thres`, `down_prob_thres`.
-* **`MLSignal(coin_cfg=None, thr=1.2, htf=None, heikin=False, model_path=None, device='cpu')`**
+* **`MLSignal(coin_cfg=None, thr=2.0, htf=None, heikin=False, model_path=None, device='cpu')`**
 
   * `fit_if_needed(df)` — build dataset (fit **RandomForest** bila perlu).
   * `predict_up_prob(df)` — probabilitas naik (kelas=1) di bar terakhir.

--- a/coin_config.json
+++ b/coin_config.json
@@ -28,12 +28,12 @@
       "time_stop_only_if_loss": 0,
       "min_roi_to_close_by_time": -1.0,
       "ml": {
-        "enabled": false,
+        "enabled": true,
         "strict": false,
-        "up_prob_long": 0.60,
-        "down_prob_short": 0.40,
-        "score_threshold": 1.00,
-        "weight": 1.0
+        "up_prob_long": 0.55,
+        "down_prob_short": 0.45,
+        "score_threshold": 2.0,
+        "weight": 1.5
       },
       "filters": {
         "atr_filter_enabled": false,
@@ -80,6 +80,15 @@
         "min_bb_width": 0.0
       },
       "ml": { "enabled": true, "strict": false, "score_threshold": 2.0, "weight": 1.5 }
+    },
+    "SCALP-ADA-15M-STRICT-HTF1H": {
+      "use_macd_confirm": true,
+      "rsi_mode": "PULLBACK",
+      "rsi_long_max": 45.0,
+      "rsi_short_min": 60.0,
+      "use_htf_filter": 1,
+      "htf": "1h",
+      "ml": { "enabled": true, "strict": false, "score_threshold": 2.0, "weight": 1.5 }
     }
   },
   "SYMBOL_DEFAULTS": {
@@ -93,7 +102,8 @@
     },
     "cooldown_seconds": 900,
     "min_bars_between_entries": 2,
-    "no_cooldown_on_profit": 1
+    "no_cooldown_on_profit": 1,
+    "use_htf_filter": 0
   },
   "ADAUSDT": {
     "use_preset": "SCALP-ADA-15M-STRICT",
@@ -187,10 +197,12 @@
       ]
     },
     "ml": {
+      "enabled": true,
       "strict": true,
       "up_prob_long": 0.55,
       "down_prob_short": 0.45,
-      "score_threshold": 1.2
+      "score_threshold": 2.0,
+      "weight": 1.5
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
@@ -247,10 +259,12 @@
       ]
     },
     "ml": {
+      "enabled": true,
       "strict": true,
       "up_prob_long": 0.55,
       "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "score_threshold": 2.0,
+      "weight": 1.5
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
@@ -307,10 +321,12 @@
       ]
     },
     "ml": {
+      "enabled": true,
       "strict": true,
       "up_prob_long": 0.55,
       "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "score_threshold": 2.0,
+      "weight": 1.5
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
@@ -367,10 +383,12 @@
       ]
     },
     "ml": {
+      "enabled": true,
       "strict": true,
       "up_prob_long": 0.55,
       "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "score_threshold": 2.0,
+      "weight": 1.5
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,
@@ -427,10 +445,12 @@
       ]
     },
     "ml": {
+      "enabled": true,
       "strict": true,
       "up_prob_long": 0.55,
       "down_prob_short": 0.45,
-      "score_threshold": 1.0
+      "score_threshold": 2.0,
+      "weight": 1.5
     },
     "use_breakeven": 1,
     "be_trigger_pct": 0.004,

--- a/engine_core.py
+++ b/engine_core.py
@@ -340,15 +340,22 @@ def make_decision(df: pd.DataFrame, symbol: str, coin_cfg: dict, ml_up_prob: flo
     return decision
 
 def htf_trend_ok(side: str, base_df: pd.DataFrame, htf: str = '1h') -> bool:
+    """
+    Gate HTF: pakai EMA22 vs SMA22 pada timeframe lebih tinggi (default 1H).
+    LONG diijinkan jika EMA22 >= SMA22; SHORT jika EMA22 <= SMA22.
+    Jika data HTF belum cukup, kembalikan True (jangan blokir).
+    """
     try:
-        tmp = base_df.set_index('timestamp')[['close']].copy()
+        d = base_df.set_index('timestamp')[['close']].copy()
         res = str(htf).upper()
-        htf_close = tmp['close'].resample(res).last().dropna()
-        if len(htf_close) < 210:
+        htf_close = d['close'].resample(res).last().dropna()
+        if len(htf_close) < 30:  # ~cukup untuk EMA/SMA22
             return True
-        ema50 = htf_close.ewm(span=20, adjust=False).mean().iloc[-1]
-        ema200 = htf_close.ewm(span=22, adjust=False).mean().iloc[-1]
-        return (ema50 >= ema200) if side == 'LONG' else (ema50 <= ema200)
+        ema22 = htf_close.ewm(span=22, adjust=False).mean().iloc[-1]
+        sma22 = htf_close.rolling(22).mean().iloc[-1]
+        if np.isnan(ema22) or np.isnan(sma22):
+            return True
+        return (ema22 >= sma22) if side == 'LONG' else (ema22 <= sma22)
     except Exception:
         return True
 def apply_filters(ind: pd.Series, coin_cfg: Dict[str, Any]) -> Tuple[bool, bool, Dict[str, Any]]:

--- a/ml_signal_plugin.py
+++ b/ml_signal_plugin.py
@@ -18,19 +18,20 @@ from engine_core import SAFE_EPS
 
 @dataclass
 class MLParams:
-    use_ml: bool = False
+    use_ml: bool = True
     score_threshold: float = 2.0
     min_train_bars: int = 400
     lookahead: int = 5
     retrain_every_bars: int = 120
     up_prob_thres: float = 0.55
     down_prob_thres: float = 0.45
+    weight: float = 1.5
 
 class MLSignal:
     def __init__(
         self,
         coin_cfg: Dict[str, Any] | None = None,
-        thr: float = 1.20,
+        thr: float = 2.0,
         htf: str | None = None,
         heikin: bool = False,
         model_path: str | None = None,
@@ -65,13 +66,14 @@ class MLSignal:
             return bool(default)
 
         self.params = MLParams(
-            use_ml=_getb('USE_ML', False),
+            use_ml=_getb('USE_ML', True),
             score_threshold=_getf('SCORE_THRESHOLD', 2.0),
             min_train_bars=_geti('ML_MIN_TRAIN_BARS', 400),
             lookahead=_geti('ML_LOOKAHEAD', 5),
             retrain_every_bars=_geti('ML_RETRAIN_EVERY', 120),
             up_prob_thres=_getf('ML_UP_PROB', 0.55),
             down_prob_thres=_getf('ML_DOWN_PROB', 0.45),
+            weight=_getf('ML_WEIGHT', 1.5),
         )
         self.model: Optional[RandomForestClassifier] = None
         self._last_fit_index: int = -1
@@ -110,9 +112,9 @@ class MLSignal:
         sc_short = 1.0 if base_short else 0.0
         if self.use_ml and (up_prob is not None):
             if up_prob >= self.params.up_prob_thres:
-                sc_long += 1.0
+                sc_long += self.params.weight
             elif up_prob <= self.params.down_prob_thres:
-                sc_short += 1.0
+                sc_short += self.params.weight
         return (sc_long >= th, sc_short >= th)
 
     # ===== dataset & fitur =====

--- a/newbacktester_scalping.py
+++ b/newbacktester_scalping.py
@@ -240,8 +240,8 @@ def main():
     os.environ.setdefault("USE_ML", "1")
     os.environ.setdefault("SCORE_THRESHOLD", "2.0")
     os.environ.setdefault("ML_MIN_TRAIN_BARS", "400")
-    os.environ.setdefault("ML_RETRAIN_EVERY", "5000")
-    os.environ.setdefault("ML_WEIGHT", "1.0")
+    os.environ.setdefault("ML_RETRAIN_EVERY", "120")
+    os.environ.setdefault("ML_WEIGHT", "1.5")
 
     summary, trades_df = run_backtest(args)
 

--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -376,7 +376,7 @@ DEFAULTS = {
 
 ENV_DEFAULTS = {
     "SLIPPAGE_PCT": 0.02,  # % per sisi
-    "SCORE_THRESHOLD": 1.2,
+    "SCORE_THRESHOLD": 2.0,
 }
 
 # ============================
@@ -830,7 +830,7 @@ class CoinTrader:
                 print(f"[{self.symbol}] FILTER INFO atr_ok={atr_ok} body_ok={body_ok} bb_ok={bb_ok} price={price} pos={self.pos.side or 'None'}")
 
             # HTF filter (opsional)
-            if _to_bool(self.config.get('use_htf_filter', DEFAULTS['use_htf_filter']), DEFAULTS['use_htf_filter']):
+            if to_bool(self.config.get('use_htf_filter', DEFAULTS['use_htf_filter']), DEFAULTS['use_htf_filter']):
                 if last['ema_22'] > last['ma_22'] and not htf_trend_ok('LONG', df, htf=htf):
                     long_htf_ok = False
                 else:
@@ -842,9 +842,13 @@ class CoinTrader:
             else:
                 long_htf_ok = short_htf_ok = True
 
-            long_base, short_base = compute_base_signals_backtest(df, self.config)
-            long_base = long_base and long_htf_ok and atr_ok and body_ok and bb_ok
-            short_base = short_base and short_htf_ok and atr_ok and body_ok and bb_ok
+            long_raw, short_raw = compute_base_signals_backtest(df, self.config)
+            if long_raw and not long_htf_ok:
+                self._log('htf_filter_blocked LONG')
+            if short_raw and not short_htf_ok:
+                self._log('htf_filter_blocked SHORT')
+            long_base = long_raw and long_htf_ok and atr_ok and body_ok and bb_ok
+            short_base = short_raw and short_htf_ok and atr_ok and body_ok and bb_ok
 
             if self.rehydrated and self.pos.side:
                 lev = _to_int(self.config.get('leverage', DEFAULTS['leverage']), DEFAULTS['leverage'])

--- a/papertrade.py
+++ b/papertrade.py
@@ -365,7 +365,7 @@ def main():
     ap.add_argument("--instance-id", default=None)
     ap.add_argument("--logs_dir", default=None)
     ap.add_argument("--risk_pct", type=float, default=None, help="Override risk_per_trade (contoh: 0.01)")
-    ap.add_argument("--ml-thr", type=float, default=1.20, help="Threshold odds ML")
+    ap.add_argument("--ml-thr", type=float, default=2.0, help="Threshold odds ML")
     ap.add_argument("--htf", default=None, help="Higher timeframe (contoh: 1h)")
     ap.add_argument("--heikin", action="store_true", help="Gunakan Heikin-Ashi")
     ap.add_argument("--fee_bps", type=float, default=10.0, help="Biaya taker per sisi (bps)")

--- a/tools_dryrun_summary.py
+++ b/tools_dryrun_summary.py
@@ -14,7 +14,7 @@ python tools_dryrun_summary.py \
   --out ADA_dryrun_trades_500.csv
 
 Tips percepat:
-export USE_ML=1; export SCORE_THRESHOLD=1.2; export ML_RETRAIN_EVERY=5000
+export USE_ML=1; export SCORE_THRESHOLD=2.0; export ML_RETRAIN_EVERY=120; export ML_WEIGHT=1.5
 """
 from __future__ import annotations
 import os, sys, time, argparse, json
@@ -154,9 +154,10 @@ def main():
 
     # saran env untuk speed
     os.environ.setdefault("USE_ML", "1")
-    os.environ.setdefault("SCORE_THRESHOLD", "1.0")
+    os.environ.setdefault("SCORE_THRESHOLD", "2.0")
     os.environ.setdefault("ML_MIN_TRAIN_BARS", "400")
-    os.environ.setdefault("ML_RETRAIN_EVERY", "5000")
+    os.environ.setdefault("ML_RETRAIN_EVERY", "120")
+    os.environ.setdefault("ML_WEIGHT", "1.5")
 
     if args.use_ml is not None:
         os.environ["USE_ML"] = str(int(args.use_ml))


### PR DESCRIPTION
## Ringkasan
- ML aktif sejak awal dengan bobot 1.5, ambang skor 2.0, serta retrain setiap 120 bar
- Tambah preset SCALP-ADA-15M-STRICT-HTF1H dan default `use_htf_filter`=0
- Fungsi HTF memakai EMA22 vs SMA22 dan logging alasan `htf_filter_blocked`

## Pengujian
- `pytest -q`
- `python -m py_compile engine_core.py ml_signal_plugin.py newrealtrading.py newbacktester_scalping.py papertrade.py tools_dryrun_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68a84da5d8c08328a21a9ec8ee1644f3