### PR TITLE
Perapihan override dan konversi waktu

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -96,7 +96,8 @@
     "no_cooldown_on_profit": 1
   },
   "ADAUSDT": {
-    "use_preset": "SCALP-ADA-15M-STRICT",
+    "use_preset": "SCALP-ADA-15M",
+    "rsi_mode": "PULLBACK",
     "leverage": 15,
     "risk_per_trade": 0.08,
     "taker_fee": 0.0005,


### PR DESCRIPTION
## Ringkasan
- Tambah _to_dt_safe dan ganti konversi waktu mentah agar tahan nilai None
- Samakan signature `_enter_position` dan `_exit_position` di berbagai monkeypatch
- Atur konfigurasi runtime papertrade serta preset ADA agar sinyal lebih longgar

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8643a82588328b88665bac1241050