### PR TITLE
Tambahkan fallback ML warmup dan parity dryrun

### DIFF
--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -813,6 +813,11 @@ class CoinTrader:
             up_prob = self.ml.predict_up_prob(df)
             if up_prob is not None:
                 up_prob = to_scalar(up_prob)
+        if up_prob is None and 'ml_signal' in df_raw.columns:
+            try:
+                up_prob = 0.60 if int(df_raw.iloc[-1]['ml_signal']) == 1 else 0.40
+            except Exception:
+                up_prob = None
 
         # ---- Cooldown berdasar virtual clock ----
         if self._cooldown_active(now_ts):

--- a/tools_dryrun_summary.py
+++ b/tools_dryrun_summary.py
@@ -96,8 +96,8 @@ def run_dry(symbol: str, csv_path: str, coin_config_path: str, steps_limit: int,
     t0 = time.time()
     steps = 0
     for i in range(start_i, min(len(df), start_i + steps_limit)):
-        data_map = {symbol: df.iloc[: i + 1].copy()}
-        mgr.run_once(data_map, {symbol: balance})
+        sub = df.iloc[: i + 1].copy()
+        trader.check_trading_signals(sub, balance)
         steps += 1
     elapsed = time.time() - t0
 


### PR DESCRIPTION
## Ringkasan
- Tambahkan mekanisme fallback saat ML belum siap supaya skor berbasis logika dasar tetap berjalan ketika strict=False
- Dryrun kini memanggil `check_trading_signals` langsung sehingga proba ML (termasuk kolom `ml_signal`) diteruskan ke `make_decision`
- `CoinTrader` memakai `ml_signal` dari CSV sebagai proba dummy bila model belum fit

## Pengujian
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a87a16544083288633dbe74c7efd80