### PR TITLE
Perbaiki handling waktu UTC dan wrapper dryrun

### DIFF
--- a/newrealtrading.py
+++ b/newrealtrading.py
@@ -447,10 +447,12 @@ class CoinTrader:
         ts_now = float(now_ts) if now_ts is not None else time.time()
         return bool(self.cooldown_until_ts and ts_now < float(self.cooldown_until_ts))
 
-    def _to_dt(self, ts: float | int | None) -> pd.Timestamp:
-        if ts is None:
-            return pd.Timestamp.utcnow().tz_localize("UTC")
-        return pd.to_datetime(float(ts), unit="s", utc=True)
+    def _to_dt(self, ts: float | int | pd.Timestamp | None) -> pd.Timestamp:
+        # Gunakan helper yang sudah tz-safe:
+        # - Timestamp aware -> tz_convert('UTC')
+        # - Naive -> tz_localize('UTC')
+        # - Epoch detik -> to_datetime(..., utc=True)
+        return _to_dt_safe(ts)
 
     def _clamp_pos(self, x: float, min_x: float = 1e-9) -> float:
         return x if (x is not None and x > min_x) else min_x


### PR DESCRIPTION
## Ringkasan
- Delegasikan `CoinTrader._to_dt` ke `_to_dt_safe` agar seluruh jalur waktu aman UTC
- Pastikan `tools_dryrun_summary` membaca timestamp sebagai UTC dan meneruskan `now_ts` dari bar terakhir
- Sesuaikan wrapper `_enter_position`/`_exit_position` dengan tanda tangan asli dan catat entri/keluar di jurnal

## Pengujian
- `pytest -q`
- `python -m py_compile newrealtrading.py tools_dryrun_summary.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87f0a22288328a81097eb430b1865