### PR TITLE
Normalisasi resample HTF dan perbaikan pipeline

### DIFF
--- a/tools_dryrun_summary.py
+++ b/tools_dryrun_summary.py
@@ -18,6 +18,7 @@ export USE_ML=1; export SCORE_THRESHOLD=2.0; export ML_RETRAIN_EVERY=5000
 """
 from __future__ import annotations
 import os, sys, time, argparse, json
+import warnings
 import pandas as pd
 import numpy as np
 from engine_core import (
@@ -28,6 +29,11 @@ from engine_core import (
 
 # pastikan bisa import modul project
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+warnings.filterwarnings(
+    "ignore",
+    category=FutureWarning,
+    message=".*is deprecated and will be removed in a future version.*",
+)
 try:
     import newrealtrading as nrt
 except Exception:


### PR DESCRIPTION
## Ringkasan
- Tambah util `_norm_resample_freq` dan perbarui `htf_trend_ok` agar memakai alias lowercase serta menghindari peringatan FutureWarning
- Turunkan argumen `--htf` ke lowercase di entry script dan trading manager
- Pasang filter FutureWarning global pada skrip eksekusi

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f458ba048328a278de25fa1d5b3a