### PR TITLE
Lazy import binance dengan filter peringatan

### DIFF
--- a/exchanges/binance_adapter.py
+++ b/exchanges/binance_adapter.py
@@ -1,0 +1,26 @@
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"^websockets(\.|$)")
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"^binance(\.|$)")
+
+_BINANCE_IMPORTED = False
+Client = None
+BinanceSocketManager = None
+BinanceAPIException = None
+
+def ensure():
+    global _BINANCE_IMPORTED, Client, BinanceSocketManager, BinanceAPIException
+    if _BINANCE_IMPORTED:
+        return
+    from binance.client import Client as _Client  # type: ignore
+    from binance.exceptions import BinanceAPIException as _BAE
+    try:
+        from binance.streams import BinanceSocketManager as _BSM
+    except Exception:
+        try:
+            from binance import ThreadedWebsocketManager as _BSM
+        except Exception:
+            _BSM = None
+    Client = _Client
+    BinanceAPIException = _BAE
+    BinanceSocketManager = _BSM
+    _BINANCE_IMPORTED = True

--- a/tools_dryrun_summary.py
+++ b/tools_dryrun_summary.py
@@ -16,9 +16,17 @@ python tools_dryrun_summary.py \
 Tips percepat:
 export USE_ML=1; export SCORE_THRESHOLD=2.0; export ML_RETRAIN_EVERY=5000
 """
+# from __future__ import harus berada di awal
 from __future__ import annotations
-import os, sys, time, argparse, json
+
+# --- force third-party deprecation ignores (so PYTHONWARNINGS=error won't fail) ---
 import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"^websockets(\.|$)")
+warnings.filterwarnings("ignore", category=DeprecationWarning, module=r"^binance(\.|$)")
+# -----------------------------------------------------------------------------
+import newrealtrading as nrt
+
+import os, sys, time, argparse, json
 import pandas as pd
 import numpy as np
 from engine_core import (
@@ -27,19 +35,11 @@ from engine_core import (
     get_coin_ml_params,
 )
 
-# pastikan bisa import modul project
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 warnings.filterwarnings(
     "ignore",
     category=FutureWarning,
     message=".*is deprecated and will be removed in a future version.*",
 )
-try:
-    import newrealtrading as nrt
-except Exception:
-    # fallback: jika tools/ ada di subfolder, coba parent
-    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-    import newrealtrading as nrt
 
 # Simpan method asli dan pasang wrapper yang tanda tangannya identik
 _orig_enter = nrt.CoinTrader._enter_position


### PR DESCRIPTION
## Ringkasan
- tambahkan filter `DeprecationWarning` untuk modul websockets dan binance pada `newrealtrading`
- buat `binance_adapter` sehingga pemanggilan binance dilakukan secara lazy
- perbarui `papertrade` agar mode `--live-paper` tidak menginisialisasi klien binance
- pasang filter peringatan sebelum import pada `tools_dryrun_summary`

## Pengujian
- `pytest -q tests/test_parity.py`
- `PYTHONWARNINGS=error python tools_dryrun_summary.py --symbol ADAUSDT --csv data/ADAUSDT_15m_2025-08-01_to_2025-08-19.csv --coin_config coin_config.json --steps 800 --balance 20`


------
https://chatgpt.com/codex/tasks/task_e_68a8fa4135a483288eeb33c46efa8643