### PR TITLE
Hotfix HTF config dan penyesuaian signature

### DIFF
--- a/newbacktester_scalping.py
+++ b/newbacktester_scalping.py
@@ -134,9 +134,9 @@ def run_backtest(args) -> tuple[dict, pd.DataFrame]:
         trader._last_used_margin = used
         return used
 
-    def _exit_wrap(price: float, reason: str = "Exit", **kw) -> None:
+    def _exit_wrap(price: float, reason: str = "Exit", now_ts: int | None = None, **kw) -> None:
         pos = trader.pos
-        ts = kw.get("now_ts", None)
+        ts = now_ts or kw.get("now_ts", None)
         exit_time = nrt._to_dt_safe(ts)
         if pos.side and pos.entry and pos.qty:
             pnl, roi = pnl_net(pos.side, float(pos.entry), float(price), float(pos.qty), args.fee_bps, args.slip_bps)
@@ -154,7 +154,7 @@ def run_backtest(args) -> tuple[dict, pd.DataFrame]:
                 "exit_time": exit_time,
             })
         trader._exit_count += 1
-        return _orig_exit(price, reason, **kw)
+        return _orig_exit(price, reason, now_ts=now_ts, **kw)
 
     trader._enter_position = _enter_wrap
     trader._exit_position = _exit_wrap

--- a/papertrade.py
+++ b/papertrade.py
@@ -342,7 +342,7 @@ class JournaledCoinTrader(CoinTrader):
     def _apply_breakeven(self, price: float) -> None:
         return super()._apply_breakeven(price)
 
-    def _enter_position(self, side: str, price: float, atr: float, available_balance: float, **kw) -> float:
+    def _enter_position(self, side, price, atr, available_balance, **kw):
         before_qty = getattr(self.pos, "qty", 0.0) or 0.0
         used = super()._enter_position(side, price, atr, available_balance, **kw)
         if self.pos.side and self.pos.qty > 0 and self.pos.qty != before_qty:
@@ -356,8 +356,8 @@ class JournaledCoinTrader(CoinTrader):
             )
         return used
 
-    def _exit_position(self, price: float, reason: str = "Exit", **kw) -> None:
-        super()._exit_position(price, reason, **kw)
+    def _exit_position(self, price, reason: str = "UNKNOWN", now_ts: int | None = None, **kw) -> None:
+        super()._exit_position(price, reason, now_ts=now_ts, **kw)
         self.journal.on_exit(self.symbol, price, reason)
 
 # -----------------------------


### PR DESCRIPTION
## Ringkasan
- Tambah util `_coerce_htf_cfg` untuk menormalkan konfigurasi HTF dan dipakai di semua akses HTF
- Perbaiki tools dryrun agar memakai util tersebut serta cast timestamp dengan aman
- Samakan tanda tangan `_enter_position`/`_exit_position` di `papertrade.py` dan `newbacktester_scalping.py`

## Pengujian
- `pytest -q tests/test_parity.py`
- `python tools_dryrun_summary.py --symbol ADAUSDT --csv data/ADAUSDT_15m_2025-08-01_to_2025-08-19.csv --coin_config coin_config.json --steps 1200 --balance 20 --out ADA_off.csv` *(gagal: FileNotFoundError)*
- `python tools_dryrun_summary.py --symbol ADAUSDT --csv data/ADAUSDT_15m_2025-08-01_to_2025-08-19.csv --coin_config coin_config.json --steps 1200 --balance 20 --out ADA_on.csv --debug-reasons` *(gagal: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68a90b73659c83289c623be1d8673014