### PR TITLE
feat: regime aware scalping enhancements

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -10,6 +10,8 @@
             "startup_skip_bars": 0,
             "min_bars_between_entries": 2,
             "cooldown_seconds": 300,
+            "cooldown_mul_hard_sl": 3.0,
+            "cooldown_max_seconds": 900,
             "no_cooldown_on_profit": 1,
             "leverage": 15,
             "risk_per_trade": 0.06,
@@ -29,6 +31,12 @@
             "break_even": {
                 "enabled": true,
                 "arm_atr_mult": 0.6
+            },
+            "bracket_exit": {
+                "enabled": true,
+                "tp1_atr_mult": 0.8,
+                "tp2_atr_mult": 1.6,
+                "tp1_size_frac": 0.5
             },
             "max_hold_seconds": 3600,
             "time_stop_only_if_loss": 1,
@@ -144,12 +152,27 @@
         "twap_force_market_on_timeout": true,
         "htf": {
             "enabled": true,
-            "timeframe": "4h",
+            "timeframe": "1h",
             "method": "ema_vs_sma",
             "ema_period": 22,
             "sma_period": 22,
             "rule": "long_ema>=sma;short_ema<=sma",
             "fallback_pass": true
+        },
+        "regime": {
+            "enabled": true,
+            "adx_period": 14,
+            "bb_period": 20,
+            "trend_threshold": 20.0,
+            "bb_width_chop_max": 0.010
+        },
+        "entry": {
+            "buffer_atr_mult": 0.12,
+            "confirm_bars": 2,
+            "allow_countertrend_short": false
+        },
+        "execution": {
+            "twap": { "enabled": false }
         },
         "cooldown_max_seconds": 900,
         "filters": {

--- a/regime.py
+++ b/regime.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from dataclasses import dataclass
+
+@dataclass
+class RegimeThresholds:
+    adx_period: int = 14
+    bb_period: int = 20
+    trend_threshold: float = 20.0
+    bb_width_chop_max: float = 0.010
+
+def compute_adx(df: pd.DataFrame, period: int) -> pd.Series:
+    high = df['high']
+    low = df['low']
+    close = df['close']
+    up = high.diff()
+    down = -low.diff()
+    plus_dm = up.where((up > down) & (up > 0), 0.0)
+    minus_dm = down.where((down > up) & (down > 0), 0.0)
+    tr = pd.concat([
+        high - low,
+        (high - close.shift()).abs(),
+        (close.shift() - low).abs()
+    ], axis=1).max(axis=1)
+    atr = tr.ewm(alpha=1/period, adjust=False).mean()
+    plus_di = 100 * (plus_dm.ewm(alpha=1/period, adjust=False).mean() / atr)
+    minus_di = 100 * (minus_dm.ewm(alpha=1/period, adjust=False).mean() / atr)
+    dx = 100 * (plus_di - minus_di).abs() / (plus_di + minus_di)
+    adx = dx.ewm(alpha=1/period, adjust=False).mean()
+    return adx
+
+def compute_bb_width(close: pd.Series, period: int=20) -> pd.Series:
+    ma = close.rolling(period).mean()
+    std = close.rolling(period).std(ddof=0)
+    upper = ma + 2*std
+    lower = ma - 2*std
+    width = (upper - lower) / ma
+    return width
+
+def get_regime(df: pd.DataFrame, th: RegimeThresholds) -> str:
+    adx = compute_adx(df, th.adx_period)
+    bbw = compute_bb_width(df['close'], th.bb_period)
+    adx_now = float(adx.iloc[-1]) if len(adx) else 0.0
+    bbw_now = float(bbw.iloc[-1]) if len(bbw) else 0.0
+    if adx_now >= th.trend_threshold and bbw_now >= th.bb_width_chop_max:
+        return 'TREND'
+    return 'CHOP'


### PR DESCRIPTION
## Ringkasan
- tambah modul `regime` untuk hitung ADX dan lebar Bollinger
- perbarui logika entry di `engine_core` dengan deteksi regime dan penalti ADX
- dukung bracket exit, BE/TSL berbasis ATR, dan normalisasi cooldown di `newrealtrading`
- tambah kolom audit baru di `tools_dryrun_summary`

## Pengujian
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a9963590f88328bf352b545c8f6e30