### PR TITLE
Tambah kill-switch debug dan perkuat TWAP any_of

### DIFF
--- a/coin_config.json
+++ b/coin_config.json
@@ -144,6 +144,13 @@
         "twap_1m_window": 120,
         "twap_atr_k": 0.55,
         "twap15_trend_mode": "any_of",
+        "debug": {
+            "bypass_twap": false,
+            "bypass_htf": false,
+            "bypass_ml": false,
+            "bypass_filters": false,
+            "force_base_entry": false
+        },
         "twap_exec_enabled": true,
         "twap_child_count": 4,
         "twap_duration_sec": 90,


### PR DESCRIPTION
## Ringkasan
- tambahkan blok `debug` pada konfigurasi ADAUSDT untuk fitur bypass diagnostik
- aktifkan berbagai kill-switch di `engine_core` termasuk bypass HTF, TWAP, ML, dan filter
- perluas `tools_dryrun_summary` agar dapat menyetel kill-switch melalui argumen CLI

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9ce27dd48328a91619cf771ca014