### PR TITLE
Refactor gating sinyal dan logging sizing

### DIFF
--- a/tools_dryrun_summary.py
+++ b/tools_dryrun_summary.py
@@ -351,6 +351,10 @@ def run_dry(
                     row["confirm_bars_used"] = locals().get("confirm_bars", None)
                     row["score_rule_only"] = locals().get("score_rule_only", None)
                     row["ml_thr_used"] = locals().get("ml_thr", None)
+                    allow_val = getattr(trader, "last_allow", False)
+                    row["allow_final"] = allow_val
+                    row["blocked_by"] = "|".join(getattr(trader, "last_allow_reasons", [])) if not allow_val else "-"
+                    row["enter_block_reason"] = getattr(trader, "last_block_reason", "-")
                     reasons_rows.append(row)
         steps += 1
     elapsed = time.time() - t0


### PR DESCRIPTION
## Ringkasan
- Normalisasi flag gating dan hitung `allow` di akhir dengan dukungan bypass dan force-base-entry.
- Tambah pencatatan alasan penolakan sizing/cooldown saat entri posisi.
- Ekspor info `allow_final`, `blocked_by`, dan `enter_block_reason` pada ringkasan dryrun.

## Pengujian
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad8e6dbec8328924cb81643aab77f